### PR TITLE
Fixed dimension of frequency threshold in 2d

### DIFF
--- a/afno/afno2d.py
+++ b/afno/afno2d.py
@@ -51,7 +51,7 @@ class AFNO2D(nn.Module):
         o2_real = torch.zeros(x.shape, device=x.device)
         o2_imag = torch.zeros(x.shape, device=x.device)
 
-        total_modes = N // 2 + 1
+        total_modes = W // 2 + 1
         kept_modes = int(total_modes * self.hard_thresholding_fraction)
 
         o1_real[:, :, :kept_modes] = F.relu(

--- a/afno/bfno2d.py
+++ b/afno/bfno2d.py
@@ -44,7 +44,7 @@ class BFNO2D(nn.Module):
         o1_real = torch.zeros([B, x.shape[1], x.shape[2], self.num_blocks, self.block_size], device=x.device)
         o1_imag = torch.zeros([B, x.shape[1], x.shape[2], self.num_blocks, self.block_size], device=x.device)
 
-        total_modes = N // 2 + 1
+        total_modes = W // 2 + 1
         kept_modes = int(total_modes * self.hard_thresholding_fraction)
 
         o1_real[:, :, :kept_modes] = torch.einsum('...bi,bio->...bo', x[:, :, :kept_modes].real, self.w1[0]) - \


### PR DESCRIPTION
Based on the paper's Figure 3: https://openreview.net/pdf?id=EXHG-A3jlM

I think the number of modes threshold in 2d
https://github.com/NVlabs/AFNO-transformer/blob/941e924ffdb34cb93897b5fd6e22e5965fdc1111/afno/afno2d.py#L54-L55
should be `W` instead of `N` since `N = H*W`, similar applies to `bfno2d.py`.

Nice paper btw. @jtguibas